### PR TITLE
fix(qgis): utilise une url où l’authentification est obligatoire

### DIFF
--- a/bibli_camino.py
+++ b/bibli_camino.py
@@ -281,7 +281,7 @@ def returnAndSaveDialogParam(self, mAction):
 #Lecture du fichier paramètre
 #==================================================
 def loadFichierParam(monFichierParam):
-    fluxAdresse, fluxTitre, fluxProvider = 'https://api.camino.beta.gouv.fr/titres?format=geojson', 'Cadastre miniers api', 'ogr'
+    fluxAdresse, fluxTitre, fluxProvider = 'https://api.camino.beta.gouv.fr/titres_qgis?format=geojson', 'Cadastre miniers api', 'ogr'
     carDebut, carFin = '[', ']'
     listWithValue = [fluxAdresse, fluxTitre, fluxProvider]
     if not FileExiste(monFichierParam) :


### PR DESCRIPTION
Pour palier au bug QGIS https://github.com/qgis/QGIS/issues/49559 il faut rendre l’authentification obligatoire pour utiliser le plugin.