### PR TITLE
Version 1.7.3: Corrige l'appel à l'API quand il y'a des substances

### DIFF
--- a/bibli_ihm_camino.py
+++ b/bibli_ihm_camino.py
@@ -512,8 +512,8 @@ def genereFiltreUrlTerritoires(self, mButton, mListDico) :
        urlCaseDico = [urlDom, urlType, urlStatus]
        # Pour infos Mapping     Corresponds aux attributs
        # "noms", "entreprises",     "substances", "references", "territoires"
-       # "nom",  "titulaires_noms", "substances", "references", "régions"
-       urlNom, urlEntreprise, urlSubstance, urlReference, urlTerritoire = "noms", "entreprises", "substances", "references", "territoires"
+       # "nom",  "titulaires_noms", "substancesIds", "references", "régions"
+       urlNom, urlEntreprise, urlSubstance, urlReference, urlTerritoire = "noms", "entreprises", "substancesIds", "references", "territoires"
        urlZoneLibreDico = [urlNom, urlEntreprise, urlSubstance, urlReference, urlTerritoire]
        urlCaseOk, mFirst, mOpe = "", True, ""
        #Pour les CheckBox
@@ -639,7 +639,7 @@ def genereFiltreUrl(self, mListDico) :
        # Pour infos Mapping     Corresponds aux attributs
        # "noms", "entreprises",     "substances", "references", "territoires"
        # "nom",  "titulaires_noms", "substances", "references", "régions"
-       urlNom, urlEntreprise, urlSubstance, urlReference, urlTerritoire = "noms", "entreprises", "substances", "references", "territoires"
+       urlNom, urlEntreprise, urlSubstance, urlReference, urlTerritoire = "noms", "entreprises", "substancesIds", "references", "territoires"
        urlZoneLibreDico = [urlNom, urlEntreprise, urlSubstance, urlReference, urlTerritoire]
        urlCaseOk, mFirst, mOpe = "", True, ""
        #Pour les CheckBox

--- a/metadata.txt
+++ b/metadata.txt
@@ -3,10 +3,14 @@ name = CAMINO Mining titles and authorizations
 description=CAMINO Mining titles and authorizations
 about=This plugin completes Camino's geographic flow supply service, the Open Digital Mining Cadastre, a web application from the French Ministry of Ecological and Solidarity Transision.
 category = Tools
-version=1.7.2
+version=1.7.3
 qgisMinimumVersion=3.0
 # Optional items:
 changelog:
+    =======================================
+    ** 1.7.3 : Michaël BITARD
+               Version under Qgis 3.28
+       * Correction of substances api call
     =======================================
     ** 1.7.2 : Didier LECLERC CMSIG MTES-MCTRCT/SG/SNUM/UNI/DRC Site de Rouen
                Version under Qgis 3.28


### PR DESCRIPTION
Bonjour @WREATCHED 

On a mis à jour nos APIs et introduit une régression sur les substances, j'ai fais le correctif dans cette PR.

En gros, l'appel à notre API qui contient des substances ne se fait plus via le champ 'substances' mais 'substancesIds'


Fix https://github.com/MTES-MCT/camino/issues/653